### PR TITLE
running keyboardrobotcontroller.py without arguments

### DIFF
--- a/components/keyboardrobotcontroller/src/keyboardrobotcontroller.py
+++ b/components/keyboardrobotcontroller/src/keyboardrobotcontroller.py
@@ -115,8 +115,8 @@ if __name__ == '__main__':
 	if len(params) > 1:
 		if not params[1].startswith('--Ice.Config='):
 			params[1] = '--Ice.Config=' + params[1]
-	elif len(params) == 0:
-		params.append('--Ice.Config=config')
+	else :# len(params) == 0:
+		params.append('--Ice.Config=/etc/config')
 	ic = Ice.initialize(params)
 	status = 0
 	mprx = {}


### PR DESCRIPTION
I have changed the code a little bit so that while running the command 
./keyboardrobotcontroller.py  
it gets connected with /etc/config if there is no commandline arguments. 
if there is some argument this will be negleted.
