### PR TITLE
Updated config file in keyboardrobotcontroller

### DIFF
--- a/components/keyboardrobotcontroller/etc/config
+++ b/components/keyboardrobotcontroller/etc/config
@@ -1,10 +1,12 @@
 # Proxies for required interfaces
-DifferentialRobotProxy = differentialrobot:tcp -h localhost -p 12238
+DifferentialRobotProxy = differentialrobot:tcp -h localhost -p 10004
+
 
 
 
 # This property is used by the clients to connect to IceStorm.
-TopicManager.Proxy=IceStorm/TopicManager:default -p 9999
+LaserProxy = laser:tcp -h localhost -p 10003
+
 
 
 Ice.Warn.Connections=0


### PR DESCRIPTION
This bug has to be fixed as the port numbers and the port proxies are incorrect in the original config. Every newcomer to the community faces this bug while using the keyboard controller for the first time.