### PR TITLE
Resolved Axis parameters errors in "config" & "config_drone" file.

### DIFF
--- a/components/hardware/external_control/joystickpublish/etc/config
+++ b/components/hardware/external_control/joystickpublish/etc/config
@@ -1,0 +1,20 @@
+CommonBehavior.Endpoints=tcp -p 10000
+
+
+# This property is used by the clients to connect to IceStorm.
+TopicManager.Proxy=IceStorm/TopicManager:default -p 9999
+
+InnerModelPath = innermodel.xml
+
+
+JoystickAdapter=JoystickAdapter
+joystickUniversal.NumAxes = 3
+joystickUniversal.Axis_0 = advance, 1, -500, 500, false  #left-right movement
+joystickUniversal.Axis_1 = rotate, 0, -500, 500, true  #front-left movement
+joystickUniversal.Axis_2 = side, 3, -500, 500, false
+#joystickUniversal.Axis_2 = clavicula, -2, -1, 0
+
+
+Ice.Warn.Connections=0
+Ice.Trace.Network=0
+Ice.Trace.Protocol=0

--- a/components/hardware/external_control/joystickpublish/etc/config_drone
+++ b/components/hardware/external_control/joystickpublish/etc/config_drone
@@ -9,11 +9,11 @@ InnerModelPath = innermodel.xml
 JoystickAdapter=JoystickAdapter
 joystickUniversal.Device = /dev/input/js0
 joystickUniversal.NumAxes = 5 
-joystickUniversal.Axis_0 = rotate, -1, 1, true  #left-right movement
-joystickUniversal.Axis_1 = advance, -1, 1, true  #front-left movement
-joystickUniversal.Axis_2 = gripper, -1, 1, true  #front-left movement
-joystickUniversal.Axis_3 = side, -1, 1, false  #front-left movement
-joystickUniversal.Axis_4 = tilt, -1, 1, false  #front-left movement
+joystickUniversal.Axis_0 = rotate, 0, -1, 1, true  #left-right movement
+joystickUniversal.Axis_1 = advance, 1, -1, 1, true  #front-left movement
+joystickUniversal.Axis_2 = gripper, 2, -1, 1, true  #front-left movement
+joystickUniversal.Axis_3 = side, 3, -1, 1, false  #front-left movement
+joystickUniversal.Axis_4 = tilt, 7, -1, 1, false  #front-left movement
 
 
 


### PR DESCRIPTION
*  Added config file without Axis parameters error at "robocomp-robolab/components/hardware/external_control/joystickpublish/etc/"
* Resolved Axis parameter error in "components/hardware/external_control/joystickpublish/etc/config_drone" file.
* Error in config files was as follows : 
    *  joystickUniversalComp::Monitor::readConfig(): ERROR reading axis. Only 4 parameters allowed 0.
       Aborted (core dumped)
    